### PR TITLE
Show thumbnails on games instead of placekittens

### DIFF
--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -20,7 +20,7 @@
     </div>
   </div>
 
-  <img class="block" src="http://placekitten.com/g/325/200" />
+  <div class="bg-mid-gray" style="background-image:url(<%= game.thumbnail %>);background-size:cover;background-position:center;width:100%;height:15rem"></div>
 
   <div class="p2">
     <h4 class="mt0 mb0">


### PR DESCRIPTION
Makes me so sad.

Also, re-inline styles. The `bg-size: cover` hack is just so that we don't need to do any resizing (temporary fix).