### PR TITLE
Moved link icon out of the link

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -36,6 +36,10 @@ body {
   color: #3C3C3C;
 }
 
+textarea {
+  resize: vertical; /* Fix to avoid ugly resizing of textareas only allowing vertical resize */
+}
+
 .dark-gray {
 	color: #3C3C3C;
 }

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -17,7 +17,7 @@
         <!-- <img src="<%= @game.thumbnail %>"> -->
         <p class="light-gray"><%= @game.description %></p>
 
-        <a class="mid-gray" href="<%= @game.link %>" target="_blank"><%= icon 'link' %> <%= @game.link %></a>
+        <%= icon 'link' %> <a class="mid-gray" href="<%= @game.link %>" target="_blank"><%= @game.link %></a>
       </div>
     </div>
 


### PR DESCRIPTION
Leaving the link icon within the link causes an ugly effect. I suggest changing it like this.