### PR TITLE
Fix built with <3 on assembly banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,7 +22,7 @@
 
     <%= yield %>
 
-    <a class="mt4 mb2" style="display: block; text-align: center;" href='https://assembly.com/product_slug?utm_campaign=assemblage&utm_source=product_slug&utm_medium=flair_widget&utm_content=dark_banner'><img src='https://treasure.assembly.com/assets/badges/dark_text_transparent-dae972d967095f44ce66d381dd861056.svg' width=243px height=34px /></a>
+    <a class="mt4 mb2" style="display: block; text-align: center;" href='https://assembly.com/gamamia?utm_campaign=assemblage&utm_source=gamamia&utm_medium=flair_widget&utm_content=dark_banner'><img src='https://treasure.assembly.com/assets/badges/dark_text_transparent-dae972d967095f44ce66d381dd861056.svg' width=243px height=34px /></a>
 
     <%= javascript_include_tag 'application' %>
 


### PR DESCRIPTION
The built with <3 on assembly banner links to a non existent page on assembly, it should now properly link to gamamia