### PR TITLE
Add tooltip component and apply it to the users avatar

### DIFF
--- a/app/assets/javascripts/objects/app.js
+++ b/app/assets/javascripts/objects/app.js
@@ -1,6 +1,7 @@
 var App = {
 	el : {
-		gameLink: $('.js-game')
+		gameLink: $('.js-game'),
+		hasTooltip: $('.has-tooltip')
 	},
 
 	init: function() {
@@ -9,10 +10,32 @@ var App = {
 
 	bindUIActions: function() {
 		App.el.gameLink.on('click', App.handleGameState)
+		App.el.hasTooltip.on('mouseover', App.handleTooltipOver)
 	},
 
 	handleGameState: function() {
 		var link = $(this).find('a').first().attr('href');
 		window.location = link;
+	},
+
+	handleTooltipOver: function() {
+		var el = $(this);
+		var text = el.data('tooltip');
+		var tooltip = jQuery('<div/>', {
+			text: text,
+			class: 'tooltip'
+		});
+
+		$('body').append(tooltip);
+
+		var top = el.position().top + el.height();
+		var left = el.position().left;
+
+		tooltip.css('top', top);
+		tooltip.css('left', left);
+
+		el.on('mouseout', function(){
+			tooltip.remove();
+		});
 	}
 }

--- a/app/assets/stylesheets/utilities/_tooltip.scss
+++ b/app/assets/stylesheets/utilities/_tooltip.scss
@@ -1,0 +1,21 @@
+.tooltip {
+  position: absolute;
+  background: black;
+  color: white;
+  margin-top: .5em;
+  padding: .25em;
+  font-size: .8em;
+  border-radius: 3px;
+
+  &:before {
+    content: '';
+  	position: absolute;
+  	top: -6px;
+    left: 6px;
+  	border-width: 0 6px 6px;
+  	border-style: solid;
+  	border-color: black transparent;
+  	display: block;
+  	width: 0;
+  }
+}

--- a/app/helpers/user_helper.rb
+++ b/app/helpers/user_helper.rb
@@ -9,7 +9,13 @@ module UserHelper
     end
 
     link_to "#", class: "block" do
-      image_tag avatar_url, class: "block circle", width: "24", height: "24"
+      image_tag(
+        avatar_url,
+        class: "block circle has-tooltip",
+        width: "24",
+        height: "24",
+        data: { tooltip: user.username }
+      )
     end
   end
 end


### PR DESCRIPTION
In order to use the tooltip component the element must have a ```.has-tooltip``` class as well as a ```data-tooltip``` attribute with the content to be shown on the tooltip.

This is the result:
![tooltip](http://i.imgur.com/fhmi85c.gif)

The ```UserHelper.avatar_for``` helper is implementing tooltip for users avatar by default.