### PR TITLE
Reverted to Daily as default

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -12,7 +12,7 @@ class GamesController < ApplicationController
     @games = @games.with_platform(params[:platform]) if params[:platform].present?
 
     @weeks = @games.includes(:user, :platforms).where("scheduled_at >= ? and scheduled_at < ?", @current_week, @next_week).scheduled.display_order.group_by do |game|
-      params[:view] == "daily" ? game.scheduled_at : game.scheduled_at.beginning_of_week
+      params[:view] == "weekly" ? game.scheduled_at.beginning_of_week : game.scheduled_at
     end.sort.reverse
   end
 

--- a/app/views/ui/_filterbar.html.erb
+++ b/app/views/ui/_filterbar.html.erb
@@ -4,11 +4,12 @@
     <div class="left">
       <ul class="list-reset clearfix m0 py2">
         <li class="left mr3">
-          <%= link_to "Weekly", games_path, :class => 'link py2' + (params[:view] ? "" : " selected") %>
+          <%= link_to "Daily", games_path, :class => 'link py2' + (params[:view] ? "" : " selected") %>
         </li>
         <li class="left">
-          <%= link_to "Daily", games_path(view: "daily"), :class => 'link py2' + (params[:view] ? " selected" : "") %>
+          <%= link_to "Weekly", games_path(view: "weekly"), :class => 'link py2' + (params[:view] ? " selected" : "") %>
         </li>
+
       </ul>
     </div>
 

--- a/app/views/weeks/_week.html.erb
+++ b/app/views/weeks/_week.html.erb
@@ -2,17 +2,17 @@
 
 
   <span class="ml1 lines">
-    <% if params[:view] == "daily"  %>
-      <% if week == Date.today %>
-        Today
-      <% else %>
-        <%= format_date(week) %>
-      <% end %>
-    <% else %>
+    <% if params[:view] == "weekly"  %>
       <% if week == Date.today.beginning_of_week %>
         This Week
       <% else %>
         Week of <%= format_date(week) %>
+      <% end %>
+    <% else %>
+      <% if week == Date.today %>
+        Today
+      <% else %>
+        <%= format_date(week) %>
       <% end %>
     <% end %>
   </span>


### PR DESCRIPTION
So I changed daily back to the default behavior for sorting. But I'm wondering if this changes pagination up a bit. Going from the beginning of the week doesn't really make sense here, especially when we are at the beginning of the week. Can we change that to the last 7 days if we are on daily view, and week by week if we are on the weekly view? I'm struggling with that a bit, @wasi or @beanieboi would love input.