### PR TITLE
Platform links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'turbolinks'
 gem 'nav_lynx'
 gem 'underscore-rails'
 gem 'cocoon'
+gem 'validate_url'
 
 gem 'html-pipeline'
 # html-pipeline dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ gem 'react-rails', '~> 1.0.0.pre', github: 'reactjs/react-rails'
 gem 'sass-rails', '~> 5.0.1'
 gem 'sdoc', '~> 0.4.0',          group: :doc
 gem 'uglifier', '>= 1.3.0'
-gem 'acts-as-taggable-on', '~> 3.4'
 gem 'cancancan', '~> 1.10'
 gem 'newrelic_rpm'
 gem 'rollbar'

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'rollbar'
 gem 'turbolinks'
 gem 'nav_lynx'
 gem 'underscore-rails'
+gem 'cocoon'
 
 gem 'html-pipeline'
 # html-pipeline dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       aws-sdk (~> 1.58)
       carrierwave (~> 0.7)
     cliver (0.3.2)
+    cocoon (1.2.6)
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
     coderay (1.1.0)
@@ -315,6 +316,7 @@ DEPENDENCIES
   cancancan (~> 1.10)
   capybara
   carrierwave-aws
+  cocoon
   codeclimate-test-reporter
   devise
   dotenv-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,8 +50,6 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    acts-as-taggable-on (3.5.0)
-      activerecord (>= 3.2, < 5)
     acts_as_votable (0.10.0)
     arel (6.0.0)
     autoprefixer-rails (5.1.7)
@@ -308,7 +306,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
-  acts-as-taggable-on (~> 3.4)
   acts_as_votable (~> 0.10.0)
   autoprefixer-rails
   bundler (>= 1.7.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     acts_as_votable (0.10.0)
+    addressable (2.3.8)
     arel (6.0.0)
     autoprefixer-rails (5.1.7)
       execjs
@@ -293,6 +294,9 @@ GEM
       execjs (>= 0.3.0)
       json (>= 1.8.0)
     underscore-rails (1.8.2)
+    validate_url (1.0.0)
+      activemodel (>= 3.0.0)
+      addressable
     warden (1.2.3)
       rack (>= 1.0)
     websocket-driver (0.5.3)
@@ -349,3 +353,4 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   underscore-rails
+  validate_url

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require underscore
+//= require cocoon
 //= require lib/jquery.events.input.js
 //= require lib/jquery-mentions.js
 //= require_tree ./objects

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,10 +1,10 @@
-//= require turbolinks
 //= require jquery
 //= require jquery_ujs
 //= require underscore
 //= require cocoon
 //= require lib/jquery.events.input.js
 //= require lib/jquery-mentions.js
+//= require turbolinks
 //= require_tree ./objects
 
 $(document).ready(function() {

--- a/app/controllers/admin/games_controller.rb
+++ b/app/controllers/admin/games_controller.rb
@@ -1,6 +1,9 @@
 module Admin
   class GamesController < ApplicationController
     load_and_authorize_resource
+
+    before_action :set_game_developers, only: [:edit, :update]
+
     def index
       @games = @games.order(:scheduled_at)
     end
@@ -10,7 +13,6 @@ module Admin
     end
 
     def edit
-      @devs = GameDeveloper.order(:title).all.pluck(:title, :id)
     end
 
     def update
@@ -31,6 +33,10 @@ module Admin
     end
 
     private
+    def set_game_developers
+      @game_developers = GameDeveloper.order(:title).all.pluck(:title, :id)
+    end
+
     def game_params
       params.require(:game).permit(:title, :thumbnail, :description, :extended_description, :status, :link, :scheduled_at, :game_developer_id, platform_list: [])
     end

--- a/app/controllers/admin/games_controller.rb
+++ b/app/controllers/admin/games_controller.rb
@@ -23,7 +23,7 @@ module Admin
         end
         redirect_to admin_games_path
       else
-        render 'new'
+        render :edit
       end
     end
 

--- a/app/controllers/admin/games_controller.rb
+++ b/app/controllers/admin/games_controller.rb
@@ -38,7 +38,22 @@ module Admin
     end
 
     def game_params
-      params.require(:game).permit(:title, :thumbnail, :description, :extended_description, :status, :link, :scheduled_at, :game_developer_id, platform_list: [])
+      params.require(:game).permit(
+        :title,
+        :thumbnail,
+        :description,
+        :extended_description,
+        :status,
+        :link,
+        :scheduled_at,
+        :game_developer_id,
+        game_platforms_attributes: [
+          :id,
+          :platform_id,
+          :url,
+          :_destroy
+        ]
+      )
     end
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -7,7 +7,7 @@ class GamesController < ApplicationController
     @last_week = @current_week - 7.days
     @next_week = @current_week + 7.days
 
-    @platforms = Game.scheduled.tags_on(:platforms)
+    @platforms = Platform.all
 
     @games = @games.with_platform(params[:platform]) if params[:platform].present?
 

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -68,6 +68,19 @@ class GamesController < ApplicationController
 
   private
   def game_params
-    params.require(:game).permit(:title, :thumbnail, :description, :extended_description, :status, :link, platform_list: [])
+    params.require(:game).permit(
+      :title,
+      :thumbnail,
+      :description,
+      :extended_description,
+      :status,
+      :link,
+      game_platforms_attributes: [
+        :id,
+        :platform_id,
+        :url,
+        :_destroy
+      ]
+    )
   end
 end

--- a/app/helpers/game_helper.rb
+++ b/app/helpers/game_helper.rb
@@ -1,2 +1,5 @@
 module GameHelper
+  def game_platforms_list(game)
+    game.platforms.map(&:name).join(", ")
+  end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -7,6 +7,8 @@ class Game < ActiveRecord::Base
 
   has_many :videos
   has_many :comments
+  has_many :game_platforms
+  has_many :platforms, through: :game_platforms
   belongs_to :user
   belongs_to :game_developer
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -27,4 +27,11 @@ class Game < ActiveRecord::Base
     touch(:deleted_at)
     freeze
   end
+
+  def find_related_platforms
+    Game
+      .joins(:platforms)
+      .where(platforms: { id: platforms.map(&:id) })
+      .where.not(games: { id: id })
+  end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -17,7 +17,7 @@ class Game < ActiveRecord::Base
   scope :unscheduled, -> { where(scheduled_at: nil) }
   scope :scheduled, -> { where('scheduled_at <= ?', Date.today) }
   scope :display_order, -> { order(:cached_votes_up).reverse_order }
-  scope :with_platform, -> (name) { tagged_with(name) }
+  scope :with_platform, -> (name) { joins(:platforms).where(platforms: { name: name }) }
 
   acts_as_votable
 

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,8 +1,6 @@
 class Game < ActiveRecord::Base
   STATUS_TYPES = ["released", 0], ["beta",1]
 
-  acts_as_taggable_on :platforms
-
   validates :title, :link, presence: true
 
   has_many :videos

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -10,6 +10,8 @@ class Game < ActiveRecord::Base
   belongs_to :user
   belongs_to :game_developer
 
+  accepts_nested_attributes_for :game_platforms, reject_if: :all_blank, allow_destroy: true
+
   default_scope -> { where(deleted_at: nil) }
 
   scope :unscheduled, -> { where(scheduled_at: nil) }

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -7,7 +7,7 @@ class Game < ActiveRecord::Base
 
   has_many :videos
   has_many :comments
-  has_many :game_platforms
+  has_many :game_platforms, dependent: :destroy
   has_many :platforms, through: :game_platforms
   belongs_to :user
   belongs_to :game_developer

--- a/app/models/game_platform.rb
+++ b/app/models/game_platform.rb
@@ -1,0 +1,4 @@
+class GamePlatform < ActiveRecord::Base
+  belongs_to :game
+  belongs_to :platform
+end

--- a/app/models/game_platform.rb
+++ b/app/models/game_platform.rb
@@ -1,4 +1,7 @@
 class GamePlatform < ActiveRecord::Base
   belongs_to :game
   belongs_to :platform
+
+  validates :game,
+            uniqueness: { scope: :platform }
 end

--- a/app/models/game_platform.rb
+++ b/app/models/game_platform.rb
@@ -4,4 +4,6 @@ class GamePlatform < ActiveRecord::Base
 
   validates :game,
             uniqueness: { scope: :platform }
+
+  validates :url, url: { allow_blank: true }
 end

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -1,2 +1,4 @@
 class Platform < ActiveRecord::Base
+  has_many :game_platforms
+  has_many :games, through: :game_platforms
 end

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -1,4 +1,4 @@
 class Platform < ActiveRecord::Base
-  has_many :game_platforms
+  has_many :game_platforms, dependent: :destroy
   has_many :games, through: :game_platforms
 end

--- a/app/models/platform.rb
+++ b/app/models/platform.rb
@@ -1,20 +1,2 @@
-class Platform
-  attr_reader :id, :name
-
-  def initialize(name)
-    @name = name
-    @id = name
-  end
-
-  def self.all
-    [
-      Platform.new('PC'),
-      Platform.new('Mac'),
-      Platform.new('Linux'),
-      Platform.new('iOS'),
-      Platform.new('Android'),
-      Platform.new('Windows Phone'),
-      Platform.new('Web')
-    ]
-  end
+class Platform < ActiveRecord::Base
 end

--- a/app/views/admin/games/_form.html.erb
+++ b/app/views/admin/games/_form.html.erb
@@ -43,7 +43,7 @@
 
   <div class="mb3">
     <%= f.label :game_developer %><br>
-    <%= f.select :game_developer_id, @devs, include_blank: true %>
+    <%= f.select :game_developer_id, @game_developers, include_blank: true %>
   </div>
 
   <div class="right-align">

--- a/app/views/admin/games/_form.html.erb
+++ b/app/views/admin/games/_form.html.erb
@@ -35,15 +35,30 @@
       <%= f.label :thumbnail %><br>
       <%= f.file_field :thumbnail %>
     </div>
-    <div class="col col-6 px2">
-      <%= f.label :platform %><br>
-      <%= f.collection_check_boxes("platform_list", Platform.all, :id, :name) %>
-    </div>
   </div>
 
   <div class="mb3">
     <%= f.label :game_developer %><br>
     <%= f.select :game_developer_id, @game_developers, include_blank: true %>
+  </div>
+
+  <fieldset class="mb3 game_platforms">
+    <legend>Platforms</legend>
+    <%= f.fields_for :game_platforms do |game_platforms| %>
+      <%= render 'game_platform_fields', f: game_platforms %>
+    <% end %>
+  </fieldset>
+
+  <div class="mb3">
+    <%= link_to_add_association(
+      'Add platform',
+      f, :game_platforms,
+      class: 'light-gray',
+      data: {
+        association_insertion_node: '.game_platforms',
+        association_insertion_method: 'append'
+      }
+    ) %>
   </div>
 
   <div class="right-align">

--- a/app/views/admin/games/_game_platform_fields.html.erb
+++ b/app/views/admin/games/_game_platform_fields.html.erb
@@ -1,0 +1,17 @@
+<div class="mb3 nested-fields">
+  <%= f.hidden_field :id %>
+  <div>
+    <%= f.label :platform_id %>
+    <br />
+    <%= f.collection_select(:platform_id, Platform.all, :id, :name) %>
+  </div>
+  <div>
+    <%= f.label :url %>
+    <br />
+    <%= f.text_field :url %>
+  </div>
+
+  <div>
+    <%= link_to_remove_association 'Remove platform', f, class: 'red' %>
+  </div>
+</div>

--- a/app/views/admin/games/index.html.erb
+++ b/app/views/admin/games/index.html.erb
@@ -18,7 +18,7 @@
             <%= link_to game.title, game %>
             <p class="mid-gray mb0"><%= game.link %></p>
           </td>
-          <td><%= game.platform_list.join(", ") %></td>
+          <td><%= game_platforms_list(game) %></td>
           <td>up: <%= game.cached_votes_up %> / down: <%= game.cached_votes_down %></td>
           <td>
             <% if game.scheduled_at? %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -17,8 +17,8 @@
           <a href="<%= @game.link %>" target="_blank"><%= icon 'link' %> <%= @game.link %></a>
 
           <ul class="list-reset platform-list">
-            <% @game.platform_list.each do |platform| %>
-              <li><%= platform %>
+            <% @game.platforms.each do |platform| %>
+              <li><%= platform.name %>
             <% end %>
           </ul>
 

--- a/db/migrate/20150505123715_create_platforms.rb
+++ b/db/migrate/20150505123715_create_platforms.rb
@@ -1,0 +1,9 @@
+class CreatePlatforms < ActiveRecord::Migration
+  def change
+    create_table :platforms do |t|
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20150505124600_create_game_platforms.rb
+++ b/db/migrate/20150505124600_create_game_platforms.rb
@@ -1,0 +1,14 @@
+class CreateGamePlatforms < ActiveRecord::Migration
+  def change
+    create_table :game_platforms do |t|
+      t.references :game, index: true
+      t.references :platform, index: true
+      t.string :url
+
+      t.timestamps null: false
+      t.index [:game_id, :platform_id], unique: true
+    end
+    add_foreign_key :game_platforms, :games
+    add_foreign_key :game_platforms, :platforms
+  end
+end

--- a/db/migrate/20150505153616_drop_acts_as_taggable_models.rb
+++ b/db/migrate/20150505153616_drop_acts_as_taggable_models.rb
@@ -1,0 +1,30 @@
+class DropActsAsTaggableModels < ActiveRecord::Migration
+  def up
+    drop_table :taggings
+    drop_table :tags
+  end
+
+  def down
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150505123715) do
+ActiveRecord::Schema.define(version: 20150505124600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,6 +37,18 @@ ActiveRecord::Schema.define(version: 20150505123715) do
     t.datetime "created_at"
     t.datetime "updated_at"
   end
+
+  create_table "game_platforms", force: :cascade do |t|
+    t.integer  "game_id"
+    t.integer  "platform_id"
+    t.string   "url"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
+  add_index "game_platforms", ["game_id", "platform_id"], name: "index_game_platforms_on_game_id_and_platform_id", unique: true, using: :btree
+  add_index "game_platforms", ["game_id"], name: "index_game_platforms_on_game_id", using: :btree
+  add_index "game_platforms", ["platform_id"], name: "index_game_platforms_on_platform_id", using: :btree
 
   create_table "games", force: :cascade do |t|
     t.string   "title",                                 null: false
@@ -165,6 +177,8 @@ ActiveRecord::Schema.define(version: 20150505123715) do
 
   add_foreign_key "comments", "games", name: "comments_game_id_fk"
   add_foreign_key "comments", "users", name: "comments_user_id_fk"
+  add_foreign_key "game_platforms", "games"
+  add_foreign_key "game_platforms", "platforms"
   add_foreign_key "games", "game_developers", name: "games_game_developer_id_fk"
   add_foreign_key "games", "users", name: "games_user_id_fk"
   add_foreign_key "identities", "users", name: "identities_user_id_fk"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150505124600) do
+ActiveRecord::Schema.define(version: 20150505153616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -100,26 +100,6 @@ ActiveRecord::Schema.define(version: 20150505124600) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
-
-  create_table "taggings", force: :cascade do |t|
-    t.integer  "tag_id"
-    t.integer  "taggable_id"
-    t.string   "taggable_type"
-    t.integer  "tagger_id"
-    t.string   "tagger_type"
-    t.string   "context",       limit: 128
-    t.datetime "created_at"
-  end
-
-  add_index "taggings", ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
-  add_index "taggings", ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
-
-  create_table "tags", force: :cascade do |t|
-    t.string  "name"
-    t.integer "taggings_count", default: 0
-  end
-
-  add_index "tags", ["name"], name: "index_tags_on_name", unique: true, using: :btree
 
   create_table "users", force: :cascade do |t|
     t.string   "email",                  default: "",   null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150428064920) do
+ActiveRecord::Schema.define(version: 20150505123715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,12 @@ ActiveRecord::Schema.define(version: 20150428064920) do
   end
 
   add_index "identities", ["user_id"], name: "index_identities_on_user_id", using: :btree
+
+  create_table "platforms", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "taggings", force: :cascade do |t|
     t.integer  "tag_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -93,3 +93,9 @@ Game.find_each do |game|
   game.videos_count = game.videos.count
   game.save!
 end
+
+platforms = ['PC', 'Mac', 'Linux', 'iOS', 'Android', 'Windows Phone', 'Web']
+
+platforms.each do |platform|
+  Platform.create!(name: platform)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,19 +6,19 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
-admin = User.create!(email:         "admin@example.com",
+admin = User.create!(email: "admin@example.com",
              password:      "password",
              name:          "Joe Smith",
-             username: "joe-smith",
+             username:      "joe-smith",
              occupation:    "Developer")
 
 User.create!(email:         "admin@email.com",
              password:      "foobarfoo",
              name:          "Joe Smith",
-             username: "joe-smith2",
+             username:      "joe-smith2",
              occupation:    "admin")
 
-Game.create!(title:          "Example Game",
+Game.create!(title:         "Example Game",
             description:    "Example description of a game, which would include a short summary of what this is all about",
             status:         "released",
             link:           "http://example.com",
@@ -31,8 +31,8 @@ Comment.create!(content:    "Example comment, which would reference a game somew
 
 Video.create!(
             title:          "Game",
-            thumbnail:       "http://placehold.it/150x150",
-            category:        "Trailer",
+            thumbnail:      "http://placehold.it/150x150",
+            category:       "Trailer",
             embed:          "https://www.youtube.com/watch?v=9ZyQK6kUdWQ",
             game_id:        1)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -36,11 +36,19 @@ Video.create!(
             embed:          "https://www.youtube.com/watch?v=9ZyQK6kUdWQ",
             game_id:        1)
 
+platform_names = ['PC', 'Mac', 'Linux', 'iOS', 'Android', 'Windows Phone', 'Web']
+
+platform_names.each do |name|
+  Platform.create!(name: name)
+end
+
+platforms = Platform.all
+
 99.times do |n|
   title  = Faker::App.name
   description = Faker::Lorem.sentence
   status = ["released", "beta"].sample
-  platform = ["Xbox", "Playstation", "PC"].sample
+  platform = platforms.sample
   votes = rand(1..15)
   created_at = Faker::Time.between(7.days.ago, Time.now)
 
@@ -56,16 +64,20 @@ Video.create!(
     occupation: occupation
   )
 
-  Game.create!(title:       title,
-             description:   description,
-             status:        status,
-             link:          "http://example.com",
-             votes:         votes,
-             created_at:    created_at,
-             updated_at:    created_at,
-             user:          user,
-             scheduled_at:  Date.today - n.days,
-             platform_list: platform)
+  Game.create!(title:         title,
+               description:   description,
+               status:        status,
+               link:          "http://example.com",
+               votes:         votes,
+               created_at:    created_at,
+               updated_at:    created_at,
+               user:          user,
+               scheduled_at:  Date.today - n.days,
+               game_platforms_attributes: [
+                 {
+                   platform_id: platform.id
+                 }
+               ])
 end
 
 199.times do |n|
@@ -92,10 +104,4 @@ Game.find_each do |game|
   game.comments_count = game.comments.count
   game.videos_count = game.videos.count
   game.save!
-end
-
-platforms = ['PC', 'Mac', 'Linux', 'iOS', 'Android', 'Windows Phone', 'Web']
-
-platforms.each do |platform|
-  Platform.create!(name: platform)
 end

--- a/spec/controllers/admin/games_controller_spec.rb
+++ b/spec/controllers/admin/games_controller_spec.rb
@@ -15,16 +15,36 @@ RSpec.describe Admin::GamesController do
       it "should assign the correct objects" do
         get :edit, id: game
         expect(assigns(:game)).to eq game
-        expect(assigns(:devs)).to_not be_nil
+        expect(assigns(:game_developers)).to_not be_nil
       end
     end
 
     describe "PATCH update" do
       it "should save tags" do
-        patch :update, {id: game.id, game: game_params.merge(platform_list: ["iOS", "Mac", "Windows"])}
-        expect(game.reload.platform_list).to include("iOS")
-        expect(game.reload.platform_list).to include("Mac")
-        expect(game.reload.platform_list).to include("Windows")
+        ios = Platform.create!(name: "iOS")
+        mac = Platform.create!(name: "Mac")
+        windows = Platform.create!(name: "Windows")
+
+        patch :update,
+              {
+                id: game.id,
+                game: game_params.merge(
+                  game_platforms_attributes: [
+                    {
+                      platform_id: ios.id
+                    },
+                    {
+                      platform_id: mac.id
+                    },
+                    {
+                      platform_id: windows.id
+                    }
+                  ]
+                )
+              }
+        expect(game.reload.platforms.map(&:name)).to include("iOS")
+        expect(game.reload.platforms.map(&:name)).to include("Mac")
+        expect(game.reload.platforms.map(&:name)).to include("Windows")
       end
 
       it "should send notification email when scheduled" do

--- a/spec/controllers/admin/games_controller_spec.rb
+++ b/spec/controllers/admin/games_controller_spec.rb
@@ -26,25 +26,22 @@ RSpec.describe Admin::GamesController do
         windows = Platform.create!(name: "Windows")
 
         patch :update,
-              {
-                id: game.id,
-                game: game_params.merge(
-                  game_platforms_attributes: [
-                    {
-                      platform_id: ios.id
-                    },
-                    {
-                      platform_id: mac.id
-                    },
-                    {
-                      platform_id: windows.id
-                    }
-                  ]
-                )
-              }
-        expect(game.reload.platforms.map(&:name)).to include("iOS")
-        expect(game.reload.platforms.map(&:name)).to include("Mac")
-        expect(game.reload.platforms.map(&:name)).to include("Windows")
+              id: game.id,
+              game: game_params.merge(
+                game_platforms_attributes: [
+                  {
+                    platform_id: ios.id
+                  },
+                  {
+                    platform_id: mac.id
+                  },
+                  {
+                    platform_id: windows.id
+                  }
+                ]
+              )
+
+        expect(game.reload.platforms.map(&:name)).to eq(['iOS', 'Mac', 'Windows'])
       end
 
       it "should send notification email when scheduled" do

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe GamesController do
 
     describe "GET index" do
       let(:game_last_week) { Fabricate :game, scheduled_at: 7.days.ago}
-      let(:game_platform_pc) { Fabricate :game, platform_list: "PC", scheduled_at: Date.today }
+      let(:game_platform_pc) { Fabricate :game, platforms: [Platform.create!(name: "PC")], scheduled_at: Date.today }
 
       subject { get :index }
 
@@ -77,7 +77,7 @@ RSpec.describe GamesController do
 
       it "assigns platforms as @platforms" do
         game_platform_pc
-        platforms = Game.scheduled.tags_on(:platforms)
+        platforms = Platform.all
         get :index
 
         expect(assigns(:platforms)).to eq(platforms)

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -52,21 +52,21 @@ RSpec.describe GamesController do
           expect(assigns(:weeks)).to eq([[week,[game]]])
         end
 
-        it "assignes scheduled games scoped by current week" do
+        it "assigns scheduled games scoped by current week" do
           game_last_week
           week = game.scheduled_at.beginning_of_week
           get :index, view: 'weekly'
           expect(assigns(:weeks)).to eq([[week,[game]]])
         end
 
-        it "assignes scheduled games scoped by last week" do
+        it "assigns scheduled games scoped by last week" do
           week = game_last_week.scheduled_at.beginning_of_week
           get :index, week: week.to_s, view: 'weekly'
 
           expect(assigns(:weeks)).to eq([[week,[game_last_week]]])
         end
 
-        it "assignes games scoped by platform" do
+        it "assigns games scoped by platform" do
           week = game.scheduled_at.beginning_of_week
           weeks = game_platform_pc
           get :index, platform: "PC", view: 'weekly'
@@ -75,7 +75,7 @@ RSpec.describe GamesController do
         end
       end
 
-      it "assignes platforms as @platforms" do
+      it "assigns platforms as @platforms" do
         game_platform_pc
         platforms = Game.scheduled.tags_on(:platforms)
         get :index

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -108,10 +108,26 @@ RSpec.describe GamesController do
       end
 
       it "should save tags" do
-        post :create, game: game_params.merge(platform_list: ["iOS", "Mac", "Windows"])
-        expect(Game.last.platform_list).to include("iOS")
-        expect(Game.last.platform_list).to include("Mac")
-        expect(Game.last.platform_list).to include("Windows")
+        ios = Platform.create!(name: "iOS")
+        mac = Platform.create!(name: "Mac")
+        windows = Platform.create!(name: "Windows")
+
+        post :create,
+             game: game_params.merge(
+               game_platforms_attributes: [
+                 {
+                   platform_id: ios.id
+                 },
+                 {
+                   platform_id: mac.id
+                 },
+                 {
+                   platform_id: windows.id
+                 }
+               ]
+             )
+
+        expect(Game.last.platforms.map(&:name)).to eq(['iOS', 'Mac', 'Windows'])
       end
     end
 
@@ -156,10 +172,16 @@ RSpec.describe GamesController do
   context "not logged in" do
     describe "GET show" do
       it "should assign related_games" do
-        game1 = Fabricate(:game, platform_list: ["ios", "web"])
-        game2 = Fabricate(:game, platform_list: ["pc"])
-        game3 = Fabricate(:game, platform_list: ["ios", "web"], scheduled_at: nil)
-        game.update_attributes platform_list: ["ios", "android"]
+        ios = Platform.create!(name: "iOS")
+        web = Platform.create!(name: "Web")
+        pc = Platform.create!(name: "PC")
+        android = Platform.create!(name: "Android")
+
+        game1 = Fabricate(:game, platforms: [ios, web])
+        game2 = Fabricate(:game, platforms: [pc])
+        game3 = Fabricate(:game, platforms: [ios, web], scheduled_at: nil)
+        game.platforms << ios
+        game.platforms << android
 
         get :show, id: game.id
         expect(assigns(:related_games)).to eq([game1])

--- a/spec/models/game_platform_spec.rb
+++ b/spec/models/game_platform_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe GamePlatform, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/game_platform_spec.rb
+++ b/spec/models/game_platform_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe GamePlatform, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should belong_to(:game) }
+  it { should belong_to(:platform) }
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -1,10 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Game do
+  let(:game) { Fabricate :game }
+
   it { should validate_presence_of(:title) }
   it { should validate_presence_of(:link) }
 
   it { should have_many(:game_platforms) }
   it { should have_many(:platforms) }
   it { should belong_to(:game_developer) }
+
+  it "should retrieve related platform games" do
+    ios = Platform.create!(name: "iOS")
+    mac = Platform.create!(name: "Mac")
+
+    ios_game1 = Fabricate(:game)
+    ios_game1.platforms << ios
+
+    ios_game2 = Fabricate(:game)
+    ios_game2.platforms << ios
+
+    mac_game = Fabricate(:game)
+    mac_game.platforms << mac
+
+    expect(ios_game1.find_related_platforms).to eq([ios_game2])
+  end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -10,19 +10,26 @@ RSpec.describe Game do
   it { should have_many(:platforms) }
   it { should belong_to(:game_developer) }
 
-  it "should retrieve related platform games" do
+  before(:each) do
     ios = Platform.create!(name: "iOS")
     mac = Platform.create!(name: "Mac")
 
-    ios_game1 = Fabricate(:game)
-    ios_game1.platforms << ios
+    @ios_game1 = Fabricate(:game)
+    @ios_game1.platforms << ios
 
-    ios_game2 = Fabricate(:game)
-    ios_game2.platforms << ios
+    @ios_game2 = Fabricate(:game)
+    @ios_game2.platforms << ios
 
-    mac_game = Fabricate(:game)
-    mac_game.platforms << mac
+    @mac_game = Fabricate(:game)
+    @mac_game.platforms << mac
+  end
 
-    expect(ios_game1.find_related_platforms).to eq([ios_game2])
+  it "should retrieve with platform" do
+    expect(Game.with_platform("Mac")).to eq([@mac_game])
+  end
+
+  it "should retrieve related platform games" do
+
+    expect(@ios_game1.find_related_platforms).to eq([@ios_game2])
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -4,5 +4,7 @@ RSpec.describe Game do
   it { should validate_presence_of(:title) }
   it { should validate_presence_of(:link) }
 
+  it { should have_many(:game_platforms) }
+  it { should have_many(:platforms) }
   it { should belong_to(:game_developer) }
 end

--- a/spec/models/platform_spec.rb
+++ b/spec/models/platform_spec.rb
@@ -1,5 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Platform, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  it { should have_many(:game_platforms) }
+  it { should have_many(:games) }
 end

--- a/spec/models/platform_spec.rb
+++ b/spec/models/platform_spec.rb
@@ -1,10 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe Platform do
-  it 'sets id and name' do
-    platform = Platform.new("my Platform")
-
-    expect(platform.id).to eq("my Platform")
-    expect(platform.name).to eq("my Platform")
-  end
+RSpec.describe Platform, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
This PR removes the acts-as-taggable-on gem and adds a nested form for platforms with a links field.

I have (re-)written some methods present in the removed gem to fix failing tests.
